### PR TITLE
#10 - Possibility to choose which comparison rule you want to use

### DIFF
--- a/EfSchemaCompare/CompareEfSqlConfig.cs
+++ b/EfSchemaCompare/CompareEfSqlConfig.cs
@@ -37,6 +37,15 @@ namespace EfSchemaCompare
         public IReadOnlyList<CompareLog> LogsToIgnore => _logsToIgnore.ToImmutableList();
 
         /// <summary>
+        /// Specifies the culture, case, and sort rules to be used
+        /// </summary>
+        public StringComparison? CaseComparison { get; set; }
+        /// <summary>
+        /// Represents a string comparison operation that uses specific case and culture-based or ordinal comparison rules. 
+        /// </summary>
+        public StringComparer CaseComparer { get; set; }
+
+        /// <summary>
         /// This allows you to clip a set of errors strings and add them as ignore items
         /// </summary>
         /// <param name="textWithNewlineBetweenErrors"></param>

--- a/EfSchemaCompare/Internal/DesignProvider.cs
+++ b/EfSchemaCompare/Internal/DesignProvider.cs
@@ -58,7 +58,7 @@ namespace EfSchemaCompare.Internal
                 .AddEntityFrameworkDesignTimeServices()
                 .AddSingleton<IOperationReporter, OperationReporter>()
                 .AddSingleton<IOperationReportHandler, OperationReportHandler>();
-
+            
             designTimeService.ConfigureDesignTimeServices(serviceCollection);
             return serviceCollection.BuildServiceProvider();
         }

--- a/EfSchemaCompare/Internal/Stage1Comparer.cs
+++ b/EfSchemaCompare/Internal/Stage1Comparer.cs
@@ -43,8 +43,8 @@ namespace EfSchemaCompare.Internal
             _relationalTypeMapping = context.GetService<IRelationalTypeMappingSource>();
             _logs = logs ?? new List<CompareLog>();
             _ignoreList = config?.LogsToIgnore ?? new List<CompareLog>();
-            _caseComparer = StringComparer.CurrentCulture;          //Turned off CaseComparer as doesn't work with EF Core 5
-            _caseComparison = _caseComparer.GetStringComparison();
+            _caseComparer = config?.CaseComparer ?? StringComparer.CurrentCulture;          //Turned off CaseComparer as doesn't work with EF Core 5
+            _caseComparison = config?.CaseComparison ?? _caseComparer.GetStringComparison();
         }
 
 

--- a/EfSchemaCompare/Internal/Stage2Comparer.cs
+++ b/EfSchemaCompare/Internal/Stage2Comparer.cs
@@ -23,7 +23,7 @@ namespace EfSchemaCompare.Internal
         {
             _databaseModel = databaseModel;
             _ignoreList = config?.LogsToIgnore ?? new List<CompareLog>();
-            _caseComparer = StringComparer.CurrentCulture;          //Turned off CaseComparer as doesn't work with EF Core 5
+            _caseComparer = config?.CaseComparer ?? StringComparer.CurrentCulture;//Turned off CaseComparer as doesn't work with EF Core 5
         }
 
         public IReadOnlyList<CompareLog> Logs => _logs.ToImmutableList();


### PR DESCRIPTION
I use EF Core 6 and it worked correctly, it will not impact other users of the library and gives the possibility for those who want to change the comparison rule

```
var comparer = new CompareEfSql(new CompareEfSqlConfig()
            {
                 CaseComparer = StringComparer.InvariantCultureIgnoreCase,
                  CaseComparison = StringComparison.InvariantCultureIgnoreCase,
            });

            if (comparer.CompareEfWithDb(_context))
            {
                return comparer.GetAllErrors;
            }
```