### PR TITLE
Modify project target framework from net7.0 to net6.0

### DIFF
--- a/DataLayer/DataLayer.csproj
+++ b/DataLayer/DataLayer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EfSchemaCompare/EfSchemaCompare.csproj
+++ b/EfSchemaCompare/EfSchemaCompare.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Modify project target framework from net7.0 to net6.0. To allow EfCore.SchemaCompare version 6.0.1 support .NET 6.