### PR TITLE
Remove dependencies on providers and support unknown ones

### DIFF
--- a/EfSchemaCompare/EfSchemaCompare.csproj
+++ b/EfSchemaCompare/EfSchemaCompare.csproj
@@ -12,11 +12,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
   </ItemGroup>
 	
   <PropertyGroup>

--- a/EfSchemaCompare/Internal/Stage1Comparer.cs
+++ b/EfSchemaCompare/Internal/Stage1Comparer.cs
@@ -10,7 +10,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
-using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 
 [assembly: InternalsVisibleTo("Test")]
@@ -210,11 +209,15 @@ namespace EfSchemaCompare.Internal
 
             var columnDict = table.Columns.ToDictionary(x => x.Name, _caseComparer);
 
+            // Imported from SqlServerAnnotationNames from SqlServer provider
+            const string sqlServerTemporalPeriodStartPropertyName = "SqlServer:TemporalPeriodStartPropertyName";
+            const string sqlServerTemporalPeriodEndPropertyName = "SqlServer:TemporalPeriodEndPropertyName";
+            
             // SQL Server only feature. Will not affect other databases
             var temporalColumnIgnores = table.GetAnnotations()
 #pragma warning disable EF1001 // Internal EF Core API usage.
-               .Where(a => a.Name == SqlServerAnnotationNames.TemporalPeriodStartPropertyName ||
-                           a.Name == SqlServerAnnotationNames.TemporalPeriodEndPropertyName)
+               .Where(a => a.Name == sqlServerTemporalPeriodStartPropertyName ||
+                           a.Name == sqlServerTemporalPeriodEndPropertyName)
 #pragma warning restore EF1001 // Internal EF Core API usage.
                .Select(a => (string)a.Value)
                .ToArray();


### PR DESCRIPTION
Hey Jon,

thanks a lot for your awesome library, i been using it for a couple of years in my projects!

With your latest version 7, the changes to the way DesignTimeServices could be handed into the Compare-Method broke compatibility with Firebird .NET provider and probably others as only three Providers (SQLite, SQL-Server & Postgres) are known to your library.

This Pull-Request changes the implementation of the factory to be a little more eager in trying to create an appropriate DatabaseModelFactory and also removes dependencies on the other providers as this is imo unncessary ballast for your library.

Feel free to leave your comments, glad to hear your feedback!